### PR TITLE
single tab don´t load xclass

### DIFF
--- a/bootstrap-shortcodes.php
+++ b/bootstrap-shortcodes.php
@@ -1182,7 +1182,7 @@ class BoostrapShortcodes {
       foreach( $atts_map as $tab ) {
         $tabs[] = sprintf(
           '<li%s><a href="#%s" data-toggle="tab">%s</a></li>',
-          ( !empty($tab["tab"]["active"]) || ($GLOBALS['tabs_default_active'] && $i == 0) ) ? ' class="active"' : '',
+          ' class="'.(( !empty($tab["tab"]["xclass"]) ) ? ''.$tab["tab"]["xclass"].'' : '').(( !empty($tab["tab"]["active"]) || ($GLOBALS['tabs_default_active'] && $i == 0) ) ? ' active' : '').'"',
           'custom-tab-' . $GLOBALS['tabs_count'] . '-' . md5($tab["tab"]["title"]),
           $tab["tab"]["title"]
         );


### PR DESCRIPTION
In documentation there is a note i can place xclass to single tab. But there is no place tu it. This can help but it´s not extra clean solution.