### PR TITLE
Popover Special Characters Fix.

### DIFF
--- a/bootstrap-shortcodes.php
+++ b/bootstrap-shortcodes.php
@@ -1521,7 +1521,9 @@ function bs_popover( $atts, $content = null ) {
     $tag = 'span';
     $content = do_shortcode($content);
     $return .= $this->get_dom_element($tag, $content, $class, $atts['title'], $atts['data']);
-    return $return;
+    
+    // added utf8_encode($return) to fix special characters issue with text being removed when a special character is used
+    return utf8_encode($return);
     
   }
 


### PR DESCRIPTION
Fixed an issue where using special characters in a popover would prevent the popover displaying text, for example: using a comma (,) would remove the rest of the text including and after the comma (,). The issue is caused by using the DOMDocument approach to writing valid XML and wouldn't be a problem if a string literal approach was used instead. (http://php.net/manual/en/domdocument.save.php - Special Characters)